### PR TITLE
clarified units for Pokémon height and weight

### DIFF
--- a/src/docs/pokemon.json
+++ b/src/docs/pokemon.json
@@ -865,7 +865,7 @@
                     },
                     {
                         "name": "height",
-                        "description": "The height of this Pokémon (decimetre).",
+                        "description": "The height of this Pokémon in decimetres.",
                         "type": "integer"
                     },
                     {
@@ -880,7 +880,7 @@
                     },
                     {
                         "name": "weight",
-                        "description": "The weight of this Pokémon (hectogram).",
+                        "description": "The weight of this Pokémon in hectograms.",
                         "type": "integer"
                     },
                     {

--- a/src/docs/pokemon.json
+++ b/src/docs/pokemon.json
@@ -865,7 +865,7 @@
                     },
                     {
                         "name": "height",
-                        "description": "The height of this Pokémon.",
+                        "description": "The height of this Pokémon (decimetre).",
                         "type": "integer"
                     },
                     {
@@ -880,7 +880,7 @@
                     },
                     {
                         "name": "weight",
-                        "description": "The weight of this Pokémon.",
+                        "description": "The weight of this Pokémon (hectogram).",
                         "type": "integer"
                     },
                     {


### PR DESCRIPTION
Addresses the issue raised in PokeAPI/pokeapi.co#19.

The documentation now states the proper units for height (decimetre) and weight (hectogram).

For example, for Garchomp (445):

- 19 decimetres = 1.9 metres
- 950 hectograms = 95 kilograms