### PR TITLE
Update CircleCI config for deploying to Firebase

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,11 @@ jobs:
     - checkout
     - run: npm install
     - run: npm run build
-    - run: ./node_modules/.bin/firebase deploy --token=$FIREBASE_DEPLOY_TOKEN --project=$FIREBASE_PROJECT_ID
+    # - run: ./node_modules/.bin/firebase deploy --token=$FIREBASE_DEPLOY_TOKEN --project=$FIREBASE_PROJECT_ID
+    - run: tar czf static_website.tar.gz public/*
+    - store_artifacts:
+        path: static_website.tar.gz
+
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,9 @@ jobs:
     - store_artifacts:
         path: static_website.tar.gz
 
+    # Trigger a new build of the deploy project
+    - run: curl -X POST --header "Content-Type: application/json" https://circleci.com/api/v1.1/project/github/PokeAPI/deploy/build?circle-token=$CIRCLECI_API_TOKEN
+
 
 workflows:
   version: 2


### PR DESCRIPTION
In preparation for deploying both the website and the API data to a single Firebase project, update this CircleCI to store a tarball of the `public` directory as an artifact and trigger a build of the `deploy` repository on CircleCI.