### PR TITLE
fixes fetch error on homepage for "Try it now!" searches

### DIFF
--- a/src/components/ApiExplorer/ApiExplorer.js
+++ b/src/components/ApiExplorer/ApiExplorer.js
@@ -26,7 +26,7 @@ export default class ApiExplorer extends React.Component {
         });
         fetch(this.props.baseApiUrl + url, {
             mode: 'cors',
-            cache: 'force-cached',
+            cache: 'force-cache',
         })
             .then(res => {
                 if (res.status === 404) {


### PR DESCRIPTION
The "Try it now!" search yields an error for all searches:

An error occurred: "TypeError: Failed to execute 'fetch' on 'Window': The provided value 'force-cached' is not a valid enum value of type RequestCache."

Reason: the value for the fetch() property 'cached' contains a typo: 'force-cached' vs. 'force-cache' which is correct according to https://fetch.spec.whatwg.org/