### PR TITLE
Add suggested changes to Pokemon/Form descriptions

### DIFF
--- a/src/docs/pokemon.json
+++ b/src/docs/pokemon.json
@@ -729,7 +729,7 @@
     },
     {
         "name": "Pokemon",
-        "description": "Pokémon are the creatures that inhabit the world of the Pokémon games. They can be caught using Pokéballs and trained by battling with other Pokémon. See [Bulbapedia](http://bulbapedia.bulbagarden.net/wiki/Pok%C3%A9mon_(species)) for greater detail.",
+        "description": "Pokémon are the creatures that inhabit the world of the Pokémon games. They can be caught using Pokéballs and trained by battling with other Pokémon.  Each Pokémon belongs to a specific species but may take on a variant which makes it differ from other Pokémon of the same species, such as base stats, available abilities and typings. See [Bulbapedia](http://bulbapedia.bulbagarden.net/wiki/Pok%C3%A9mon_(species)) for greater detail.",
         "exampleRequest": "/v2/pokemon/{id or name}/",
         "exampleResponse": {
             "id": 12,
@@ -1238,7 +1238,7 @@
     },
     {
         "name": "Pokémon Forms",
-        "description": "Some Pokémon have the ability to take on different forms. At times, these differences are purely cosmetic and have no bearing on the difference in the Pokémon's stats from another; however, several Pokémon differ in stats (other than HP), type, and Ability depending on their form.",
+        "description": "Some Pokémon may appear in one of multiple, visually different forms. These differences are purely cosmetic. For variations within a Pokémon species, which do differ in more than just visuals, the 'Pokémon' entity is used to represent such a variety.",
         "exampleRequest": "/v2/pokemon-form/{id or name}/",
         "exampleResponse": {
             "id": 413,


### PR DESCRIPTION
@Finrod_Amandil suggested a couple of changes to the docs in PokeAPI/pokeapi#401 to clarify the confusion between Pokemon and PokemonForm resources. I think they look good. Should we merge them?