### PR TITLE
Fix some errors in docs

### DIFF
--- a/src/docs/moves.json
+++ b/src/docs/moves.json
@@ -440,7 +440,7 @@
                     {
                         "name": "accuracy",
                         "description": "The percent value of how likely this move is to be successful.",
-                        "type": "PastMoveStatValues"
+                        "type": "integer"
                     },
                     {
                         "name": "effect_chance",

--- a/src/docs/moves.json
+++ b/src/docs/moves.json
@@ -334,7 +334,7 @@
                 ]
             },
             {
-                "name": "MoveAilment",
+                "name": "MoveMetaData",
                 "fields": [
                     {
                         "name": "ailment",
@@ -647,7 +647,7 @@
         },
         "responseModels": [
             {
-                "name": "ModelName",
+                "name": "MoveDamageClass",
                 "fields": [
                     {
                         "name": "id",

--- a/src/docs/moves.json
+++ b/src/docs/moves.json
@@ -294,7 +294,10 @@
                         "description": "A list of moves to use before this move.",
                         "type": {
                             "type": "list",
-                            "of": "NamedAPIResource"
+                            "of": {
+                                "type": "NamedAPIResource",
+                                "of": "Move"
+                            }
                         }
                     },
                     {
@@ -302,7 +305,10 @@
                         "description": "A list of moves to use after this move.",
                         "type": {
                             "type": "list",
-                            "of": "NamedAPIResource"
+                            "of": {
+                                "type": "NamedAPIResource",
+                                "of": "Move"
+                            }
                         }
                     }
                 ]
@@ -319,16 +325,22 @@
                         "name": "language",
                         "description": "The language this name is in.",
                         "type": {
-                            "type": "NamedAPIResource ",
-                            "of": "Language"
+                            "type": "list",
+                            "of": {
+                                "type": "NamedAPIResource",
+                                "of": "Move"
+                            }
                         }
                     },
                     {
                         "name": "version_group",
                         "description": "The version group that uses this flavor text.",
                         "type": {
-                            "type": "NamedAPIResource ",
-                            "of": "VersionGroup"
+                            "type": "list",
+                            "of": {
+                                "type": "NamedAPIResource",
+                                "of": "Move"
+                            }
                         }
                     }
                 ]

--- a/src/docs/pokemon.json
+++ b/src/docs/pokemon.json
@@ -99,7 +99,7 @@
                         "description": "The effect of this ability listed in different languages.",
                         "type": {
                              "type": "list",
-                             "of": "names"
+                             "of": "VerboseEffect"
                          }
                     },
                     {


### PR DESCRIPTION
Found these while trying to generate TypeScript definitions. I haven't tried generating docs from this yet.