### PR TITLE
Add Poke-Api-V2 ruby gem wrapper to list of wrappers in docs

### DIFF
--- a/src/components/Alerts/Alerts.js
+++ b/src/components/Alerts/Alerts.js
@@ -61,7 +61,7 @@ const Alerts = () => {
             />
         ));
     }
-    return;
+    return null;
 };
 
 export default Alerts;

--- a/src/pages/docs/v2.html.js
+++ b/src/pages/docs/v2.html.js
@@ -156,6 +156,13 @@ export default ({location}) => (
                     </a>{' '}
                     by lmerotta
                 </li>
+                <li>
+                    <strong>Ruby</strong>:{' '}
+                    <a href="https://github.com/rdavid1099/poke-api-v2">
+                        Poke-Api-V2
+                    </a>{' '}
+                    by rdavid1099
+                </li>
             </ul>
 
             <h2 id="resource-lists-section">Resource Lists and Pagination</h2>


### PR DESCRIPTION
Added my Ruby gem wrapper `Poke-Api-V2` (https://github.com/rdavid1099/poke-api-v2) (https://rubygems.org/gems/poke-api-v2) to list of wrappers.

_NOTE_: I added a `return null;` to Alerts.js on line 64 because Gatsby was not allowing anything to render without that in the local dev environment. If you would like me to revert that to a simple `return;` just tell me. Thank you.