### PR TITLE
add .Net Standard PokeApiNet wrapper

### DIFF
--- a/src/pages/docs/v2.html.js
+++ b/src/pages/docs/v2.html.js
@@ -138,6 +138,13 @@ export default ({location}) => (
                     by PoroCYon
                 </li>
                 <li>
+                    <strong>.NET Standard</strong>
+                    <a href="https://github.com/mtrdp642/PokeApiNet">
+                        PokeApiNet
+                    </a>{' '}
+                    by mtrdp642
+                </li>
+                <li>
                     <strong>Swift</strong>:{' '}
                     <a href="https://github.com/ContinuousLearning/PokemonKit">
                         PokemonKit


### PR DESCRIPTION
I created a wrapper library targeting .Net Standard 2.0 that just got published for use. I'll submit an additional PR to add this to the list of wrappers to the readme as well in the main repo.