### PR TITLE
Added Go wrapper to Docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ yarn-error.log
 .firebase/
 
 package-lock.json
+yarn.lock

--- a/src/pages/docs/v2.html.js
+++ b/src/pages/docs/v2.html.js
@@ -163,6 +163,13 @@ export default ({location}) => (
                     </a>{' '}
                     by rdavid1099
                 </li>
+                <li>
+                    <strong>Go</strong>:{' '}
+                    <a href="https://github.com/mtslzr/pokeapi-go">
+                        pokeapi-go
+                    </a>{' '}
+                    by mtslzr
+                </li>
             </ul>
 
             <h2 id="resource-lists-section">Resource Lists and Pagination</h2>


### PR DESCRIPTION
Added my wrapper, [pokeapi-go](https://github.com/mtslzr/pokeapi-go), to the Docs pages.

Also added `yarn.lock` to .gitignore so it didn't commit.