### PR TITLE
Enable staging deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ workflows:
     jobs:
       - build-test-and-deploy:
           requires:
-            - test
+            - build-and-test
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
           path: static_website.tar.gz
       - run: 
           name: Trigger a deploy of the deploy project passing the desired environment/location to deploy to
-          command: 'curl --header "Content-Type: application/json" --data "{\"build_parameters\": {\"deploy_location\": \"$CIRCLE_BRANCH\", \"CIRCLE_JOB\": \"deploy\"}}" --request POST "https://circleci.com/api/v1.1/project/github/PokeAPI/deploy/tree/test-staging?circle-token=$CIRCLECI_API_TOKEN"'
+          command: 'curl --header "Content-Type: application/json" --data "{\"build_parameters\": {\"deploy_location\": \"$CIRCLE_BRANCH\", \"CIRCLE_JOB\": \"deploy\"}}" --request POST "https://circleci.com/api/v1.1/project/github/PokeAPI/deploy/tree/test-staging?circle-token=$CIRCLECI_API_TOKEN"' # TODO: replace `test-staging` with `master`
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,12 @@ commands:
   build:
     description: Install dependencies and build the project
     steps:
-      - run: npm install -E
-      - run: npm run build
+      - run: 
+          name: Install exact dependencies
+          command: npm install -E
+      - run: 
+          name: Build the website
+          command: npm run build
 
 jobs:
   build-and-test:
@@ -24,12 +28,14 @@ jobs:
     steps:
       - checkout
       - build
-      - run: tar czf static_website.tar.gz -C public .
+      - run: 
+          name: Pack the website in a .tar.gz
+          command: tar czf static_website.tar.gz -C public .
       - store_artifacts:
           path: static_website.tar.gz
-
-      # Trigger a new build of the deploy job of the deploy project
-      - run: 'curl --header "Content-Type: application/json" --data "{\"build_parameters\": {\"deploy_location\": \"$CIRCLE_BRANCH\", \"CIRCLE_JOB\": \"deploy\"}}" --request POST "https://circleci.com/api/v1.1/project/github/PokeAPI/deploy/tree/test-staging?circle-token=$CIRCLECI_API_TOKEN"'
+      - run: 
+          name: Trigger a deploy of the deploy project passing the desired environment/location to deploy to
+          command: 'curl --header "Content-Type: application/json" --data "{\"build_parameters\": {\"deploy_location\": \"$CIRCLE_BRANCH\", \"CIRCLE_JOB\": \"deploy\"}}" --request POST "https://circleci.com/api/v1.1/project/github/PokeAPI/deploy/tree/test-staging?circle-token=$CIRCLECI_API_TOKEN"'
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,12 +5,12 @@ executors:
     docker:
       - image: circleci/node:10.11.0
 
-  commands:
-    build:
-      description: Install dependencies and build the project
-      steps:
-        - run: npm install -E
-        - run: npm run build
+commands:
+  build:
+    description: Install dependencies and build the project
+    steps:
+      - run: npm install -E
+      - run: npm run build
 
 jobs:
   build-and-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,9 +33,9 @@ jobs:
           command: tar czf static_website.tar.gz -C public .
       - store_artifacts:
           path: static_website.tar.gz
-      - run: 
+      - run:
           name: Trigger a deploy of the deploy project passing the desired environment/location to deploy to
-          command: 'curl --header "Content-Type: application/json" --data "{\"build_parameters\": {\"deploy_location\": \"$CIRCLE_BRANCH\", \"CIRCLE_JOB\": \"deploy\"}}" --request POST "https://circleci.com/api/v1.1/project/github/PokeAPI/deploy/tree/test-staging?circle-token=$CIRCLECI_API_TOKEN"' # TODO: replace `test-staging` with `master`
+          command: 'curl --header "Content-Type: application/json" --data "{\"build_parameters\": {\"deploy_location\": \"$CIRCLE_BRANCH\", \"CIRCLE_JOB\": \"deploy\"}}" --request POST "https://circleci.com/api/v1.1/project/github/PokeAPI/deploy/tree/master?circle-token=$CIRCLECI_API_TOKEN"'
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,9 @@
 version: 2.1
 
 executors:
-  node10:
+  node12:
     docker:
-      - image: circleci/node:10.11.0
+      - image: circleci/node:12.16.3
 
 commands:
   build:
@@ -14,13 +14,13 @@ commands:
 
 jobs:
   build-and-test:
-    executor: node10
+    executor: node12
     steps:
       - checkout
       - build
 
   build-test-and-deploy:
-    executor: node10
+    executor: node12
     steps:
       - checkout
       - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,30 +1,48 @@
-version: 2
+version: 2.1
 
-defaults: &defaults
-  docker:
-    - image: circleci/node:10.11.0
+executors:
+  node10:
+    docker:
+      - image: circleci/node:10.11.0
+
+  commands:
+    build:
+      description: Install dependencies and build the project
+      steps:
+        - run: npm install -E
+        - run: npm run build
 
 jobs:
-  build-and-test-and-deploy:
-    <<: *defaults
+  build-and-test:
+    executor: node10
     steps:
-    - checkout
-    - run: npm install -E
-    - run: npm run build
-    - run: tar czf static_website.tar.gz -C public .
-    - store_artifacts:
-        path: static_website.tar.gz
+      - checkout
+      - build
 
-    # Trigger a new build of the deploy project
-    - run: "curl -X POST --header \"Content-Type: application/json\" https://circleci.com/api/v1.1/project/github/PokeAPI/deploy/build?circle-token=$CIRCLECI_API_TOKEN"
+  build-test-and-deploy:
+    executor: node10
+    steps:
+      - checkout
+      - build
+      - run: tar czf static_website.tar.gz -C public .
+      - store_artifacts:
+          path: static_website.tar.gz
 
+      # Trigger a new build of the deploy job of the deploy project
+      - run: 'curl --header "Content-Type: application/json" --data "{\"build_parameters\": {\"deploy_location\": \"$CIRCLE_BRANCH\", \"CIRCLE_JOB\": \"deploy\"}}" --request POST "https://circleci.com/api/v1.1/project/github/PokeAPI/deploy/tree/test-staging?circle-token=$CIRCLECI_API_TOKEN"'
 
 workflows:
   version: 2
-
-  commit:
+  test:
     jobs:
-      - build-and-test-and-deploy:
+      - build-and-test
+  test-and-deploy:
+    jobs:
+      - build-test-and-deploy:
+          requires:
+            - test
           filters:
             branches:
-              only: master
+              only:
+                - master
+                - staging

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,7 @@ workflows:
       - build-and-test
   test-and-deploy:
     jobs:
+      - build-and-test
       - build-test-and-deploy:
           requires:
             - build-and-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,9 +33,6 @@ jobs:
 
 workflows:
   version: 2
-  test:
-    jobs:
-      - build-and-test
   test-and-deploy:
     jobs:
       - build-and-test


### PR DESCRIPTION
This PR allows invoking in a conditional manner a new _deploy_ job present in the `PokeAPI/deploy` CircleCI configuration. This job will automatically deploy the `pokeapi.co` website to our productive environment (pokeapi.co) or to a new staging environment.  The job will be invoked only when the `master` or `staging` branches of this repository are pushed to. If the `master` is getting pushed then the `master` branch will be deployed in the productive environment. Viceversa, if the `staging` branch is pushed, then the `staging` branch will be deployed in the staging environment. 

A more descriptive and general overview is detailed in this https://github.com/PokeAPI/pokeapi/pull/488 PR.


---

This PR is linked to the following PRs: 
- https://github.com/PokeAPI/deploy/pull/10  
- https://github.com/PokeAPI/api-data/pull/42 
- https://github.com/PokeAPI/pokeapi/pull/488

__When https://github.com/PokeAPI/deploy/pull/10 will be merged we need to change `.circleci/config.yml#38`__

This PR should be merged after https://github.com/PokeAPI/deploy/pull/10