### PR TITLE
Fixed the type of location_area_encounters

### DIFF
--- a/src/docs/pokemon.json
+++ b/src/docs/pokemon.json
@@ -921,7 +921,10 @@
                     {
                         "name": "location_area_encounters",
                         "description": "A link to a list of location areas, as well as encounter details pertaining to specific versions.",
-                        "type": "string"
+                        "type": {
+                             "type": "list",
+                             "of": "LocationAreaEncounter"
+                         }
                     },
                     {
                         "name": "moves",


### PR DESCRIPTION
The documentation previously stated that the type of the property "location_area_ecounters" in Pokemon was a `string`, instead of a list of `LocationAreaEncounter`.