### PR TITLE
Rename ModelName to MoveCategory

### DIFF
--- a/src/docs/moves.json
+++ b/src/docs/moves.json
@@ -597,7 +597,7 @@
         },
         "responseModels": [
             {
-                "name": "ModelName",
+                "name": "MoveCategory",
                 "fields": [
                     {
                         "name": "id",


### PR DESCRIPTION
Also fixes a link to `MoveCategory` type in `MoveMetaData.category`