### PR TITLE
Update updown.io links

### DIFF
--- a/src/pages/status.js
+++ b/src/pages/status.js
@@ -13,10 +13,10 @@ export default function StatusPage() {
 
             <ul>
                 <li>
-                    <a href="https://updown.io/pryw">Documentation Status</a>
+                    <a href="https://updown.io/md8f">Documentation Status</a>
                 </li>
                 <li>
-                    <a href="https://updown.io/akzp">API Status</a>
+                    <a href="https://updown.io/w04a">API Status</a>
                 </li>
             </ul>
         </PlainPage>


### PR DESCRIPTION
Free Updown.io credits using pokeapi.co@gmail.com have been used.

This PR changes the links to the same status pages created using my Updown.io account.