### PR TITLE
[docs] Typo on `types` of PokemonForm

### DIFF
--- a/src/docs/pokemon.json
+++ b/src/docs/pokemon.json
@@ -1561,7 +1561,7 @@
                          }
                     },
                     {
-                        "name": "type",
+                        "name": "types",
                         "description": "A list of details showing types this Pokémon form has.",
                         "type": {
                              "type": "NamedAPIResource",


### PR DESCRIPTION
Small fix, just to rename the property `type` to `types` as this is the return of the API