### PR TITLE
Reference Rust library in api documentation

### DIFF
--- a/src/pages/docs/v2.js
+++ b/src/pages/docs/v2.js
@@ -94,6 +94,12 @@ const wrapperLibraries = [
         link: 'https://github.com/Gabb-c/pokenode-ts',
         author: 'Gabb-c',
     },
+    {
+        description: 'Rust with auto caching',
+        name: 'Rustemon',
+        link: 'https://crates.io/crates/rustemon',
+        author: 'mlemesle',
+    },
 ];
 
 export default function Documentation() {


### PR DESCRIPTION
Hello !

I wrote a wrapping library covering the whole PokeApi v2 in Rust, with auto caching.
Since there is no such Rust library referenced in the documentation on the website, I was wondering if referencing mine was possible.

This is what this PR is for. I just added the informations in the corresponding array. 
Please find attached a screenshot of the result.

Please let me know if this is OK for you.
I stay available if you have some remarks.
Have a good day !

<img width="1232" alt="image" src="https://user-images.githubusercontent.com/33993288/140388489-0ffded8c-2b5d-4e40-80b5-44681c6ee9af.png">
