### PR TITLE
fix: PokemonSprite.types wrong typing in the doc

### DIFF
--- a/src/docs/pokemon.json
+++ b/src/docs/pokemon.json
@@ -1564,7 +1564,7 @@
                         "name": "types",
                         "description": "A list of details showing types this Pokémon form has.",
                         "type": {
-                             "type": "NamedAPIResource",
+                             "type": "list",
                              "of": "PokemonFormType"
                          }
                     },


### PR DESCRIPTION
The doc displays the wrong data type for field "types" of PokemonSprite.

Example:
This is the result of query:  https://pokeapi.co/api/v2/pokemon-form/1

![example](https://user-images.githubusercontent.com/75539244/150684669-b1d57383-682e-4330-8f52-cfaae4e306c1.png)

It should be a list of PokemonFormType but instead it displays:

![original](https://user-images.githubusercontent.com/75539244/150684707-681a812d-b5f5-4970-bd07-95f4c0c2205e.png)

Visible changes after the fix:

![change](https://user-images.githubusercontent.com/75539244/150684730-effc1d56-3c2c-4257-9c8a-43b3b772a71b.png)


