### PR TITLE
Add pokeapi-scala to docs

### DIFF
--- a/src/pages/docs/v2.js
+++ b/src/pages/docs/v2.js
@@ -111,6 +111,12 @@ const wrapperLibraries = [
         name: 'aiopokeapi',
         link: 'https://github.com/beastmatser/aiopokeapi',
         author: 'beastmatser'
+    },
+    {
+        description: 'Scala 3 with auto caching',
+        name: 'pokeapi-scala',
+        link: 'https://github.com/juliano/pokeapi-scala',
+        author: 'Juliano Alves',
     }
 ];
 


### PR DESCRIPTION
I've written a [wrapper to the api in Scala 3](https://github.com/juliano/pokeapi-scala), this pr adds the [already published](https://search.maven.org/artifact/io.github.juliano/pokeapi-scala_3/0.1.0/jar) library to the list of wrapper libraries.