### PR TITLE
Add an elixir lib and fix doc link

### DIFF
--- a/src/docs/moves.json
+++ b/src/docs/moves.json
@@ -496,7 +496,7 @@
     },
     {
         "name": "Move Ailments",
-        "description": "Move Ailments are status conditions caused by moves used during battle. See [Bulbapedia](http://bulbapedia.bulbagarden.net/wiki/http://bulbapedia.bulbagarden.net/wiki/Status_condition) for greater detail.",
+        "description": "Move Ailments are status conditions caused by moves used during battle. See [Bulbapedia](https://bulbapedia.bulbagarden.net/wiki/Status_condition) for greater detail.",
         "exampleRequest": "/v2/move-ailment/{id or name}/",
         "exampleResponse": {
             "id": 1,

--- a/src/pages/docs/v2.js
+++ b/src/pages/docs/v2.js
@@ -88,11 +88,11 @@ const wrapperLibraries = [
         link: 'https://github.com/mtslzr/pokeapi-go',
         author: 'mtslzr',
     },
-	{
-		description: 'Crystal',
-		name: 'pokeapi',
-		link: 'https://github.com/henrikac/pokeapi',
-		author: 'henrikac',
+    {
+        description: 'Crystal',
+        name: 'pokeapi',
+        link: 'https://github.com/henrikac/pokeapi',
+        author: 'henrikac',
     },
     {
         description: 'Typescript with auto caching',
@@ -110,14 +110,20 @@ const wrapperLibraries = [
         description: 'Asynchronous Python wrapper with auto caching',
         name: 'aiopokeapi',
         link: 'https://github.com/beastmatser/aiopokeapi',
-        author: 'beastmatser'
+        author: 'beastmatser',
     },
     {
         description: 'Scala 3 with auto caching',
         name: 'pokeapi-scala',
         link: 'https://github.com/juliano/pokeapi-scala',
         author: 'Juliano Alves',
-    }
+    },
+    {
+        description: 'Elixir wrapper with auto caching',
+        name: 'Max-Elixir-PokeAPI',
+        link: 'https://github.com/HenriqueArtur/Max-Elixir-PokeAPI',
+        author: 'Henrique Artur',
+    },
 ];
 
 export default function Documentation() {


### PR DESCRIPTION
I check every link on pages e fix a bulbapedia in "Move Ailments".

I found this link to 404 page `https://phalt.github.io/posts/if-you-have-data-they-will-consume-it/` in the explanation of the change from v1 to v2.

And finally, add a elixir wrapper that I created.

My vscode linter tweaked some lines in other array elements. 😅