### PR TITLE
Fix Broken Hyperlink to pokeapi.co in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
 [![build status](https://img.shields.io/circleci/build/github/PokeAPI/pokeapi.co/master.svg)](https://circleci.com/gh/PokeAPI/pokeapi.co)
 
-This repository contains the source code and documentation for [pokeapi.co](pokeapi.co). This website is built on [React-Static](https://react-static.js.org), a static site generator similar to [Gatsby](https://www.gatsbyjs.org/), except unopinionated and with less magic.
+This repository contains the source code and documentation for [pokeapi.co](https://pokeapi.co/). This website is built on [React-Static](https://react-static.js.org), a static site generator similar to [Gatsby](https://www.gatsbyjs.org/), except unopinionated and with less magic.
 
 ## Getting Started
 


### PR DESCRIPTION
### Issue:

The hyperlink to `pokeapi.co` is interpreted as a relative path, leading to a GitHub 404 page instead of the actual PokeAPI website when clicked from the README.

### Resolution:

Updated the URL to include the `https://` prefix, ensuring proper redirection.

With this correction, anyone reading the README will be directed to the correct PokeAPI website upon clicking the link.
