### PR TITLE
Update website and link to contributors

### DIFF
--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -8,7 +8,7 @@ export default function Footer({id}) {
         <footer id={id} className={styles.footer}>
             <div className={styles.container}>
                 <div>
-                    Created by <a href="https://phalt.github.io/">Paul Hallett</a> and other <a href="https://github.com/PokeAPI/pokeapi#contributing">PokéAPI contributors</a> around the world. Pokémon and Pokémon character names are trademarks of Nintendo.
+                    Created by <a href="https://github.com/phalt">Paul Hallett</a> and other <a href="https://github.com/PokeAPI/pokeapi/graphs/contributors">PokéAPI contributors</a> around the world. Pokémon and Pokémon character names are trademarks of Nintendo.
                 </div>
                 <div>
                     <a href="https://pokeapi.statuspage.io/"><img alt="Status" src="https://img.shields.io/badge/dynamic/json?color=blue&label=status&query=%24.status.description&url=https%3A%2F%2Fzlfyqp3hlvly.statuspage.io%2Fapi%2Fv2%2Fsummary.json"></img></a>

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -102,14 +102,7 @@ export default function About() {
                     PokéAPI V1 was created by{' '}
                     <a href="https://github.com/phalt">Paul Hallett</a> as a
                     weekend project but it quickly became more than a weekend's
-                    worth of work. In{' '}
-                    <a
-                        href="https://phalt.github.io/posts/if-you-have-data-they-will-consume-it/"
-                        target="none"
-                    >
-                        December of 2014
-                    </a>{' '}
-                    Paul deprecated V1 in favor of working on V2.
+                    worth of work. In December of 2014 Paul deprecated V1 in favor of working on V2.
                 </p>
                 <p>
                     This is where{' '}


### PR DESCRIPTION
Context:

- My personal website is no longer this, it is just my Github page.
- The contributors page has it's own link now on GitHub.