### PR TITLE
Correct type of 'used_move' field in an evolution chain

### DIFF
--- a/src/docs/evolution.json
+++ b/src/docs/evolution.json
@@ -250,7 +250,7 @@
                         "description": "The move that must be used by the evolving Pokémon species during the evolution trigger event in order to evolve into this Pokémon species.",
                         "type": {
                             "type": "NamedAPIResource",
-                            "of": "PokemonMove"
+                            "of": "Move"
                         }
                     },
                     {


### PR DESCRIPTION
Fixing a typo in my previous PR, mentioned in https://github.com/PokeAPI/pokeapi/issues/1395