### PR TITLE
docs: Fixes PokeAPI/pokeapi#1399 fix flavor_text_entries type for Con…

### DIFF
--- a/src/docs/contests.json
+++ b/src/docs/contests.json
@@ -131,7 +131,25 @@
                         "description": "The flavor text of this contest effect listed in different languages.",
                         "type": {
                              "type": "list",
-                             "of": "FlavorText"
+                             "of": "ContestEffectFlavorText"
+                         }
+                    }
+                ]
+            },
+            {
+                "name": "ContestEffectFlavorText",
+                "fields": [
+                    {
+                        "name": "flavor_text",
+                        "description": "The localized flavor text for an API resource in a specific language.",
+                        "type": "string"
+                    },
+                    {
+                        "name": "language",
+                        "description": "The language this name is in.",
+                        "type": {
+                             "type": "NamedAPIResource",
+                             "of": "Language"
                          }
                     }
                 ]
@@ -176,7 +194,7 @@
                         "description": "The flavor text of this super contest effect listed in different languages.",
                         "type": {
                              "type": "list",
-                             "of": "FlavorText"
+                             "of": "SuperContestEffectFlavorText"
                          }
                     },
                     {
@@ -188,6 +206,24 @@
                                  "type": "NamedAPIResource",
                                  "of": "Move"
                              }
+                         }
+                    }
+                ]
+            },
+            {
+                "name": "SuperContestEffectFlavorText",
+                "fields": [
+                    {
+                        "name": "flavor_text",
+                        "description": "The localized flavor text for an API resource in a specific language.",
+                        "type": "string"
+                    },
+                    {
+                        "name": "language",
+                        "description": "The language this name is in.",
+                        "type": {
+                             "type": "NamedAPIResource",
+                             "of": "Language"
                          }
                     }
                 ]


### PR DESCRIPTION
Link to Original Issue:
https://github.com/PokeAPI/pokeapi/issues/1399#issuecomment-4067145852

Fixes PokeAPI/pokeapi#1399
Replaced incorrect FlavorText type (which includes version) with ContestEffectFlavorText and SuperContestEffectFlavorText respectively for the flavor_text_entries field in both endpoints.

I initially was going to remove version as directed; however, after double checking the full project files, I found that FlavorText is also PokemonSpecies.flavor_text_entries, which correctly returns a version field since Pokédex entries vary between game versions. Removing version from the shared FlavorText type would have broken that endpoint's documentation.

Why does version not apply to contest endpoints?
I checked source CSVs (contest_effect_prose.csv, super_contest_effect_prose.csv) and the build script in _build_contests(), neither file has a version column. The backend models ContestEffectFlavorText and SuperContestEffectFlavorText also have no HasVersion mixin, confirming version was never part of this data. 

I couldn't find any version specific data for contest effects when searching online. That is to say, the entries were the same for each version.

Please see link to original issue for more details.