### PR TITLE
Update base_form type for evolution details

### DIFF
--- a/src/docs/evolution.json
+++ b/src/docs/evolution.json
@@ -242,7 +242,7 @@
                         "description": "The required form for which this evolution can occur.",
                         "type": {
                             "type": "NamedAPIResource",
-                            "of": "PokemonSpecies"
+                            "of": "Pokemon"
                         }
                     },
                     {


### PR DESCRIPTION
Small PR to update the `base_form` field for evolution chains from `PokemonSpecies` to `Pokemon`, matching changes from PokeAPI/pokeapi#1492