### PR TITLE
feat: Add pokelance to list of wrappers

### DIFF
--- a/src/pages/docs/v2.js
+++ b/src/pages/docs/v2.js
@@ -35,6 +35,18 @@ const wrapperLibraries = [
         author: 'Paul Hallett',
     },
     {
+        description: 'Asynchronous Python wrapper with auto caching',
+        name: 'aiopokeapi',
+        link: 'https://github.com/beastmatser/aiopokeapi',
+        author: 'beastmatser',
+    },
+    {
+        description: 'Async Python wrapper with typed models, smart caching, and auto endpoint discovery',
+        name: 'PokeLance',
+        link: 'https://github.com/FallenDeity/PokeLance',
+        author: 'FallenDeity',
+    },
+    {
         description: 'Kotlin Multiplatform (JVM, Native, Browser, and Node) with auto caching',
         name: 'PokeKotlin',
         link: 'https://github.com/PokeAPI/pokekotlin',
@@ -111,12 +123,6 @@ const wrapperLibraries = [
         name: 'Rustemon',
         link: 'https://crates.io/crates/rustemon',
         author: 'mlemesle',
-    },
-    {
-        description: 'Asynchronous Python wrapper with auto caching',
-        name: 'aiopokeapi',
-        link: 'https://github.com/beastmatser/aiopokeapi',
-        author: 'beastmatser',
     },
     {
         description: 'Scala 3 with auto caching',


### PR DESCRIPTION
Hi added a reference to an asynchronous python wrapper I wrote for pokeapi, few differences from the already existing one include smarter caching both data + media along with disk persistence ability, auto endpoint discovery and smart errors, a modular extension based endpoint group system and typed models with validation. and up to date with most recent field changes/additions

repo: https://github.com/FallenDeity/PokeLance
docs: https://fallendeity.github.io/PokeLance/